### PR TITLE
Fix code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/src/routes/category.router.js
+++ b/src/routes/category.router.js
@@ -14,7 +14,12 @@ routerCategory.route('/')
   .get(getAll)
   .post(createCategoryLimiter, verifyJWT, create);
 
+const removeCategoryLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 routerCategory.route('/:id')
-  .delete(verifyJWT, remove)
+  .delete(removeCategoryLimiter, verifyJWT, remove)
 
 module.exports = routerCategory;


### PR DESCRIPTION
Fixes [https://github.com/jduval15/backend-final/security/code-scanning/3](https://github.com/jduval15/backend-final/security/code-scanning/3)

To fix the problem, we need to apply a rate limiter to the `remove` route in the same way it is applied to the `create` route. This involves using the `express-rate-limit` middleware to limit the number of requests that can be made to the `remove` route within a specified time window.

- We will create a rate limiter configuration similar to the one used for the `create` route.
- We will then apply this rate limiter to the `remove` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
