### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/src/routes/product.router.js
+++ b/src/routes/product.router.js
@@ -1,19 +1,25 @@
 const { getAll, create, getOne, remove, update, setImages } = require('../controllers/product.controllers');
 const express = require('express');
 const verifyJWT = require('../utils/verifyJWT');
+const rateLimit = require('express-rate-limit');
 
 const routerProduct = express.Router();
 
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 routerProduct.route('/')
   .get(getAll)
-  .post(verifyJWT, create);
+  .post(verifyJWT, limiter, create);
 
 routerProduct.route('/:id/images')
-  .post(verifyJWT, setImages)
+  .post(verifyJWT, limiter, setImages)
 
 routerProduct.route('/:id')
   .get(getOne)
-  .delete(verifyJWT, remove)
-  .put(verifyJWT, update);
+  .delete(verifyJWT, limiter, remove)
+  .put(verifyJWT, limiter, update);
 
 module.exports = routerProduct;


### PR DESCRIPTION
Fixes [https://github.com/jduval15/backend-final/security/code-scanning/7](https://github.com/jduval15/backend-final/security/code-scanning/7)

To fix the problem, we will introduce rate limiting to the routes that use the `verifyJWT` middleware. We will use the `express-rate-limit` package to achieve this. Specifically, we will:
1. Install the `express-rate-limit` package.
2. Set up a rate limiter with appropriate configuration.
3. Apply the rate limiter to the routes that use the `verifyJWT` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
