### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/src/routes/product.router.js
+++ b/src/routes/product.router.js
@@ -12,7 +12,7 @@ const limiter = rateLimit({
 
 routerProduct.route('/')
   .get(getAll)
-  .post(verifyJWT, create);
+  .post(verifyJWT, limiter, create);
 
 routerProduct.route('/:id/images')
   .post(verifyJWT, limiter, setImages)


### PR DESCRIPTION
Potential fix for [https://github.com/jduval15/backend-final/security/code-scanning/22](https://github.com/jduval15/backend-final/security/code-scanning/22)

To fix the problem, we need to add rate limiting to the `create` route handler. This can be done by applying the existing `limiter` middleware to the `create` route. This will ensure that the route is protected against denial-of-service attacks by limiting the number of requests that can be made to it within a specified time window.

The changes required are:
1. Add the `limiter` middleware to the `create` route handler in the `routerProduct.route('/')` definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
